### PR TITLE
Warn if no realms configured

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible.pm
@@ -582,6 +582,9 @@ on_plugin_import {
     # get settings
     $load_settings->();
 
+    warn "No Auth::Extensible realms configured with which to authenticate user"
+        unless keys %{ $settings->{realms} };
+
     if ( !$settings->{no_default_pages} ) {
         $app->add_route(
             method => 'get',


### PR DESCRIPTION
I spent some time debugging my code, only to find that I'd not written the config options correctly. This patch warns if no realms are configured.