### PR TITLE
Add DBIC support

### DIFF
--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/Base.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/Base.pm
@@ -3,6 +3,8 @@ package Dancer2::Plugin::Auth::Extensible::Provider::Base;
 use strict;
 use Crypt::SaltedHash;
 
+our $VERSION = '0.303';
+
 =head1 NAME
 
 Dancer2::Plugin::Auth::Extensible::Provider::Base - base class for authentication providers

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/Config.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/Config.pm
@@ -3,6 +3,8 @@ package Dancer2::Plugin::Auth::Extensible::Provider::Config;
 use strict;
 use base "Dancer2::Plugin::Auth::Extensible::Provider::Base";
 
+our $VERSION = '0.303';
+
 =head1 NAME 
 
 Dancer2::Plugin::Auth::Extensible::Config - example auth provider using app config

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/Database.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/Database.pm
@@ -5,6 +5,7 @@ use base 'Dancer2::Plugin::Auth::Extensible::Provider::Base';
 use Dancer2::Plugin::Database;
 use Dancer2 qw(:syntax);
 
+our $VERSION = '0.303';
 
 =head1 NAME 
 

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/Example.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/Example.pm
@@ -3,6 +3,8 @@ package Dancer2::Plugin::Auth::Extensible::Provider::Example;
 use strict;
 use base "Dancer2::Plugin::Auth::Extensible::Provider::Base";
 
+our $VERSION = '0.303';
+
 # A more sensible provider would be likely to get this information from e.g. a
 # database (or LDAP, or...) rather than hardcoding it.  This, however, is an
 # example.

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/LDAP.pm
@@ -5,6 +5,8 @@ use base "Dancer2::Plugin::Auth::Extensible::Provider::Base";
 use Net::LDAP;
 use Dancer2 qw(warning);
 
+our $VERSION = '0.303';
+
 =head1 NAME 
 
 Dancer2::Plugin::Auth::Extensible::LDAP - LDAP authentication provider

--- a/lib/Dancer2/Plugin/Auth/Extensible/Provider/Unix.pm
+++ b/lib/Dancer2/Plugin/Auth/Extensible/Provider/Unix.pm
@@ -5,6 +5,8 @@ use base 'Dancer2::Plugin::Auth::Extensible::Provider::Base';
 use Authen::Simple::PAM;
 use Unix::Passwd::File;
 
+our $VERSION = '0.303';
+
 =head1 NAME
 
 Dancer2::Plugin::Auth::Extensible::Unix - authenticate *nix system accounts


### PR DESCRIPTION
In order to add DBIC support, changes to the overall plugin were needed. This was so that the DBIC schema could be retrieved using $dsl->schema. The schema has to be captured on module load, otherwise it's not available in later calls.

Without version information, Dancer throws errors when trying to print the version information on module load.